### PR TITLE
Add lodash / mongo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ We'll be going through several core features that Derby provides. Along the way,
 
 To get started:
 
-```
+```shell
 # Get the repo
 > git clone https://github.com/lever/derby-tutorial.git
 > cd derby-tutorial
 
 # Install dependencies
 > npm install
+
+# Start Mongo
+> docker-compose -f ./docker-compose.yaml up
 
 # Start the server
 > node src/server.js

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ To get started:
 # Install dependencies
 > npm install
 
-# Start Mongo
+# Start Mongo with Docker Compose...
 > docker-compose -f ./docker-compose.yaml up
+# OR, if you don't want to use Docker Compose...
+> docker run -d --rm mongo:3.4
 
 # Start the server
 > node src/server.js

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,6 @@
+version: "3"
+services:
+  mongo:
+    image: mongo:3.4
+    ports:
+      - "27017:27017"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "derby-starter": "^0.4.7",
     "express": "^4.16.4",
     "faker": "^4.1.0",
+    "lodash": "^4.17.11",
     "racer": "^0.9.3",
     "racer-bundle": "^0.3.0",
     "sharedb-mingo-memory": "^1.1.0"


### PR DESCRIPTION
Fixes: `Error: Cannot find module 'lodash'`
Fixes: `MongoError: failed to connect to server [localhost:27017] on first connect [MongoError: connect ECONNREFUSED 127.0.0.1:27017]` by adding a `docker-compose.yaml` and instructions to do the same without compose.